### PR TITLE
Размытие фона при открытии слоя управления анекдотами #62

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,14 +13,11 @@
 </head>
 
 <body>
-  <main>
-    <!-- panel right -->
-    <section>
-      <!-- content -->
-      <aside>
-        <!-- sidebar left -->
+  <input type="checkbox" id="layer-editor-toggle" hidden />
 
-        <!-- left sidebar -->
+  <main> <!-- panel right -->
+    <section> <!-- content -->
+      <aside> <!-- sidebar left -->
         <header id="logo">
           <h1>Анекдоты</h1>
         </header>
@@ -35,8 +32,7 @@
         </footer>
       </aside>
 
-      <!-- content -->
-      <div id="content">
+      <div id="content"> <!-- content -->
         <header id="search">
           поиск
         </header>
@@ -52,39 +48,12 @@
       </div>
     </section>
 
-    <!-- right panel -->
-    <div id="panel">
+    <div id="panel"> <!-- right panel -->
       <header>
-        <input type="checkbox" id="layer-editor-toggle" hidden />
-        <label for="layer-editor-toggle" id="splash"></label>
-        <article class="layer editor">
-          <label for="layer-editor-toggle">
-            <span>управление</span>
-            <span class="button">добавить</span>
-          </label>
-
-          <div class="form" id="editor">
-            <form id="input-anekdot">
-              <h3>Добавить анекдот</h3>
-              <input type="text" name="name" placeholder="Название" /></br>
-              <textarea name="text" id="" cols="30" rows="10" placeholder="текст"></textarea></br>
-              <input type="submit" value="Сохранить" /></br>
-            </form>
-
-            <form class="form" id="input-tag">
-              <h3>Добавить тег</h3>
-              <input type="text" name="name" placeholder="Тег" /></br>
-              <input type="submit" value="Сохранить" /></br>
-              <div class="tags">
-                <ul class="aside list tags "></ul>
-              </div>
-            </form>
-
-
-
-          </div>
-        </article>
-
+        <label for="layer-editor-toggle">
+          <span>управление</span>
+          <span class="button">добавить</span>
+        </label>
       </header>
       <div id="next-anekdot">
         <div>
@@ -96,6 +65,30 @@
       </footer>
     </div>
   </main>
-</body>
 
+  <label for="layer-editor-toggle" id="splash"></label>
+  <article class="layer editor">
+    <header>
+      <label for="layer-editor-toggle">закрыть</label>
+    </header>
+    <div class="form" id="editor">
+      <form id="input-anekdot">
+        <h3>Добавить анекдот</h3>
+        <input type="text" name="name" placeholder="Название" />
+        <textarea name="text" id="" cols="30" rows="10" placeholder="текст"></textarea>
+        <input type="submit" value="Сохранить" />
+      </form>
+
+      <form id="input-tag">
+        <h3>Добавить тег</h3>
+        <input type="text" name="name" placeholder="Тег" />
+        <input type="submit" value="Сохранить" />
+        <div class="tags">
+          <ul class="aside list tags "></ul>
+        </div>
+      </form>
+    </div>
+  </article>
+
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-  <input type="checkbox" id="layer-editor-toggle" hidden />
+  <input type="checkbox" id="layer-editor-toggle" class="splash" hidden />
 
   <main> <!-- panel right -->
     <section> <!-- content -->
@@ -66,10 +66,14 @@
     </div>
   </main>
 
-  <label for="layer-editor-toggle" id="splash"></label>
-  <article class="layer editor">
+  <div id="splash"> <!-- splash -->
+    <label for="layer-editor-toggle"></label>
+  </div>
+
+  <!-- layers -->
+  <article class="layer" id="layer-editor"> <!-- layer-editor -->
     <header>
-      <label for="layer-editor-toggle">закрыть</label>
+      <label for="layer-editor-toggle" class="button">закрыть</label>
     </header>
     <div class="form" id="editor">
       <form id="input-anekdot">

--- a/style.less
+++ b/style.less
@@ -69,7 +69,7 @@ body    { .color(@color-paper); }
 section { .color(@color-white); }
 aside   { .color(@color-prime); }
 
-main {.animate(.3s);}
+main { .animate(.3s); }
 
 /** @secton sidebar left */
 ul.list.aside.tags, ul.list.aside.anekdots { margin-left: 10%; margin-top: 20px; list-style: none; }
@@ -83,7 +83,6 @@ article#anekdot { width: 50%; .center; }
 article#anekdot h2 { margin-bottom: 40px; }
 
 /** @section panel right */
-input#layer-editor-toggle ~ article { .animate(.3s); top: 0; right: 0; width: 0; height: 0; position: fixed; }
 input#layer-editor-toggle ~ article form { display: block; overflow: hidden; width: 0; }
 label[for="layer-editor-toggle"] { display: block; text-align: right; padding: 1em; }
 label[for="layer-editor-toggle"] span { .cursor; margin-left: 1em;
@@ -92,12 +91,8 @@ label[for="layer-editor-toggle"] span { .cursor; margin-left: 1em;
 label[for="layer-editor-toggle"] span.button { .inline; .color(@color-second, @color-black); .round(5px); padding: 5px 10px; .edge(@color-shadow);
   &:hover { .edge(@color-second); .color(@color-paper, blue); }
 }
-#splash { display: none; background: fade(@color-second, 70%); .bind(0,0,0,auto,absolute); width: 100vw; }
 input#layer-editor-toggle {
-  &:checked ~ article { .color(@color-prime); .shadow(-@shadow-offset, 0, @shadow-blur, @color-shadow); .size(55%, 100%); box-sizing: border-box; }
   &:checked ~ article form { width: auto; .inline; vertical-align: top; .sizing; margin: 2%; }
-  &:checked ~ #splash { display: block; }
-  &:checked ~ main { filter: blur(3px); }
 }
 #editor { font-size: 0; height: 0; }
 #editor form { font-size: 16px; }
@@ -115,3 +110,16 @@ div#next-anekdot div { display: inline-block; vertical-align: middle; padding: 5
   &:hover { cursor: pointer; .color(@color-paper, blue); }
 }
 
+/** @subsection layers */
+article.layer { .animate(.3s); top: 0; right: 0; width: 0; height: 0; position: fixed; .color(@color-prime); box-sizing: border-box; }
+#layer-editor-toggle:checked ~ #layer-editor { .size(55%, 100%); .shadow(-@shadow-offset, 0, @shadow-blur, @color-shadow);  }
+
+/** @subsection splash */
+#splash { display: none;  background: fade(@color-second, 70%); .bind(0, 0, 0, 0, fixed);
+  & > label { display: none; height: 100%; }
+}
+input.splash { display: none;
+  &:checked ~ #splash { display: block; }
+  &:checked ~ main { filter: blur(3px); }
+}
+#layer-editor-toggle:checked ~ #splash > label[for="layer-editor-toggle"] { display: block; }

--- a/style.less
+++ b/style.less
@@ -69,6 +69,8 @@ body    { .color(@color-paper); }
 section { .color(@color-white); }
 aside   { .color(@color-prime); }
 
+main {.animate(.3s);}
+
 /** @secton sidebar left */
 ul.list.aside.tags, ul.list.aside.anekdots { margin-left: 10%; margin-top: 20px; list-style: none; }
 ul.list.aside.tags li, ul.list.aside.anekdots li {
@@ -81,7 +83,7 @@ article#anekdot { width: 50%; .center; }
 article#anekdot h2 { margin-bottom: 40px; }
 
 /** @section panel right */
-input#layer-editor-toggle ~ article { .animate(.3s); top: 0; right: 0; width: 100%; height: 25%; position: absolute; }
+input#layer-editor-toggle ~ article { .animate(.3s); top: 0; right: 0; width: 0; height: 0; position: fixed; }
 input#layer-editor-toggle ~ article form { display: block; overflow: hidden; width: 0; }
 label[for="layer-editor-toggle"] { display: block; text-align: right; padding: 1em; }
 label[for="layer-editor-toggle"] span { .cursor; margin-left: 1em;
@@ -92,9 +94,10 @@ label[for="layer-editor-toggle"] span.button { .inline; .color(@color-second, @c
 }
 #splash { display: none; background: fade(@color-second, 70%); .bind(0,0,0,auto,absolute); width: 100vw; }
 input#layer-editor-toggle {
-  &:checked ~ article { .color(@color-prime); .shadow(-@shadow-offset, 0, @shadow-blur, @color-shadow); .size(60vw, 100vh); box-sizing: border-box; }
+  &:checked ~ article { .color(@color-prime); .shadow(-@shadow-offset, 0, @shadow-blur, @color-shadow); .size(55%, 100%); box-sizing: border-box; }
   &:checked ~ article form { width: auto; .inline; vertical-align: top; .sizing; margin: 2%; }
   &:checked ~ #splash { display: block; }
+  &:checked ~ main { filter: blur(3px); }
 }
 #editor { font-size: 0; height: 0; }
 #editor form { font-size: 16px; }


### PR DESCRIPTION
При открытии слоя управления анекдотами размывается фон-контент сайта

- [x] При клике на размытой области, слой редактирования закрывается
- [x] (вёрстка) слой редактирования и чекбокс вынесены напрямую в `<body>`
  - Можно аналогичным образом добавлять новые слои
- [ ] Имеет смысл отрефакторить `HTML` и `LESS` код (в рамках отдельной задачи)